### PR TITLE
feat: add Docker setup for contract tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-bullseye
+WORKDIR /app
+COPY consumer ./consumer
+COPY provider ./provider
+RUN cd consumer && npm ci
+RUN cd provider && npm ci
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,32 @@ npm install
 npm test
 ```
 
+### Uso con Docker
+
+Para aislar el entorno y ejecutar las pruebas dentro de un contenedor:
+
+```bash
+docker build -t contract-testing .
+```
+
+```bash
+docker run --rm -it -v $(pwd)/pacts:/app/pacts contract-testing
+```
+
+Dentro del contenedor, las dependencias ya están instaladas y se pueden ejecutar las pruebas manualmente:
+
+```bash
+cd consumer && npm test
+cd ../provider && npm test
+```
+
+También se incluye un `docker-compose.yml` para ejecutar cada servicio en su propio contenedor compartiendo el volumen `./pacts`:
+
+```bash
+docker compose run --rm consumer
+docker compose run --rm provider
+```
+
 ## Publicación en Pactflow
 
 Para publicar los contratos generados en un servidor Pactflow:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  consumer:
+    build: .
+    volumes:
+      - ./pacts:/app/pacts
+    working_dir: /app/consumer
+    command: npm test
+  provider:
+    build: .
+    volumes:
+      - ./pacts:/app/pacts
+    working_dir: /app/provider
+    command: npm test


### PR DESCRIPTION
## Summary
- add Dockerfile installing dependencies for consumer and provider
- provide docker-compose services with shared pact volume
- document Docker usage in README

## Testing
- `cd consumer && npm install`
- `npm test`
- `cd ../provider && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bef87b15f8832ea85f1787d7dd46f3